### PR TITLE
Change to use sunraster instead of irispy for iris module

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ variables:
   CI_NAME: Azure Pipelines
   CI_BUILD_ID: $(Build.BuildId)
   CI_BUILD_URL: "https://dev.azure.com/sunpy/sunpy/_build/results?buildId=$(Build.BuildId)"
-  CIBW_BUILD: cp36-* cp37-* cp38-*
+  CIBW_BUILD: cp37-* cp38-*
   CIBW_SKIP: "*-manylinux1_i686"
 
 resources:
@@ -35,6 +35,6 @@ jobs:
       apt:
         - libxkbcommon-x11-0
     envs:
-      - macos: py36
+      - macos: py37
       - windows: py37
       - linux: py38

--- a/glue_solar/instruments/iris/iris.py
+++ b/glue_solar/instruments/iris/iris.py
@@ -11,8 +11,8 @@ from glue.config import data_factory, importer, qglue_parser
 from glue.core import Component, Data
 from glue.core.data_factories import load_data
 from glue.core.coordinates import WCSCoordinates
-from irispy.spectrograph import (IRISSpectrograph,
-                                 read_iris_spectrograph_level2_fits)
+from sunraster.io.iris import read_iris_spectrograph_level2_fits
+from sunraster import SpectrogramCube
 
 from .stack_spectrograms import stack_spectrogram_sequence
 from .iris_loader import QtIRISImporter
@@ -21,7 +21,7 @@ from .iris_loader import QtIRISImporter
 __all__ = ['import_iris', 'read_iris_raster', '_parse_iris_raster']
 
 
-@qglue_parser(IRISSpectrograph)
+@qglue_parser(SpectrogramCube)
 def _parse_iris_raster(data, label):
     result = []
     for window, window_data in data.data.items():

--- a/glue_solar/instruments/iris/iris_loader.py
+++ b/glue_solar/instruments/iris/iris_loader.py
@@ -7,11 +7,13 @@ from glue.core import Component, Data
 from glue.core.coordinates import WCSCoordinates
 from glue.utils.qt import get_qapp
 from glue.utils.qt.helpers import load_ui
-from irispy.spectrograph import read_iris_spectrograph_level2_fits
+from sunraster.io.iris import read_iris_spectrograph_level2_fits
+from sunraster import SpectrogramCube
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 
 from .stack_spectrograms import stack_spectrogram_sequence
+
 
 __all__ = ["QtIRISImporter"]
 

--- a/glue_solar/instruments/iris/stack_spectrograms.py
+++ b/glue_solar/instruments/iris/stack_spectrograms.py
@@ -1,5 +1,6 @@
 """
 Reproject a series of IRIS raster scans in to one NDCube.
+
 """
 import numpy as np
 import tempfile
@@ -12,7 +13,7 @@ from astropy.time import Time
 from astropy.wcs import WCS
 from reproject.interpolation import reproject_interp
 
-from irispy.spectrograph import read_iris_spectrograph_level2_fits
+from sunraster.io.iris import read_iris_spectrograph_level2_fits
 from ndcube import NDCube
 
 

--- a/scripts/iris_viewer.py
+++ b/scripts/iris_viewer.py
@@ -5,7 +5,7 @@ from glue.core import Data, DataCollection
 from glue.core.data_factories import load_data
 from glue.plugins.wcs_autolinking.wcs_autolinking import wcs_autolink
 from glue_solar.instruments.iris import _parse_iris_raster
-from irispy.spectrograph import read_iris_spectrograph_level2_fits
+from sunraster.io.iris import read_iris_spectrograph_level2_fits
 
 from glue.viewers.image.qt import ImageViewer
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ long_description = file: README.rst
 
 [options]
 zip_safe = False
-python_requires = >=3.6
+python_requires = >=3.7
 packages = find:
 install_requires =
     astropy
@@ -20,6 +20,7 @@ install_requires =
     reproject
     ndcube
     dask[array]
+    sunraster
 
 [options.extras_require]
 tests =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38},build_docs
+envlist = py{37,38},build_docs
 
 [testenv]
 passenv =


### PR DESCRIPTION
<!-- # Pull Request Template -->

## Description
To update the dependency of glue-solar for the `instruments/iris` module from the outdated `irispy` to the just officially released `sunraster` v0.1. 

Have tested the plugin minimally by launching `glue` (or `glueviz`) with the updated version installed. Have update(s) to change the `IRISSpectrograph` import to
```
from sunraster import SpectrogramCube
```
 to render the `instruments/iris` module fully functional. Further follow-up changes may be necessary. 