### PR TITLE
Update IRIS data labels with OBSID for filtering

### DIFF
--- a/glue_solar/instruments/iris/iris.py
+++ b/glue_solar/instruments/iris/iris.py
@@ -29,9 +29,9 @@ def _parse_iris_raster(data, label):
     w_dataset = []
     for window, window_data in data.items():
         for i, scan_data in enumerate(window_data):
-            w_data = Data(label=f"{window.replace(' ', '_')}-scan-{i}")
+            w_data = Data(label=f"{window.replace(' ', '_')}-{scan_data.meta['OBSID']}-scan-{i}")
             w_data.coords = WCSCoordinates(scan_data.wcs.to_header())
-            w_data.add_component(Component(scan_data.data), f"{window.replace(' ', '_')}-scan-{i}")
+            w_data.add_component(Component(scan_data.data), f"{window.replace(' ', '_')}-{scan_data.meta['OBSID']}-scan-{i}")
             w_data.meta = scan_data.meta
             w_data.style = VisualAttributes(color='#5A4FCF')
             w_dataset.append(w_data)

--- a/glue_solar/instruments/iris/loader.py
+++ b/glue_solar/instruments/iris/loader.py
@@ -87,7 +87,7 @@ class QtIRISImporter(QtWidgets.QDialog):
     def load_sji(self, sji):
         with fits.open(sji) as hdul:
             hdul.verify("fix")
-            label = hdul[0].header['TDESC1']
+            label = hdul[0].header['TDESC1'] + hdul[0].header['OBSID']
             data = Data(label=label)
             data.coords = WCSCoordinates(hdul[0].header)
             data.meta = hdul[0].header
@@ -113,10 +113,10 @@ class QtIRISImporter(QtWidgets.QDialog):
     def load_sequence(self, raster_data):
         for window, window_data in raster_data.items():
             for i, scan_data in enumerate(window_data):
-                w_data = Data(label=f"{window.replace(' ', '_')}-scan-{i}")
+                w_data = Data(label=f"{window.replace(' ', '_')}-{scan_data.meta['OBSID']}-scan-{i}")
                 w_data.coords = scan_data.wcs
                 w_data.add_component(Component(scan_data.data),
-                                     f"{window}-scan-{i}")
+                                     f"{window.replace(' ', '_')}-scan-{i}")
                 w_data.meta = scan_data.meta
                 w_data.style = VisualAttributes(color='#5A4FCF')
                 self.datasets.append(w_data)
@@ -126,7 +126,7 @@ class QtIRISImporter(QtWidgets.QDialog):
             w_data = Data(label=f"{window.replace(' ', '_')}")
             w_data.coords = window_data.wcs
             w_data.add_component(Component(window_data.data),
-                                 f"{window}")
+                                 f"{window.replace(' ', '_')}")
             self.datasets.append(w_data)
 
     def finalize(self):


### PR DESCRIPTION
<!-- # Pull Request Template -->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes #10. Adds the `OBSID` detail that is unique to each observation to the data labels of IRIS data as uploaded with either the file uploader or directory uploader. Only changes the label. Primary aim is for better filtering of IRIS observational data.  

For one observation:
<img width="1438" alt="Screenshot 2020-06-20 04 08 26" src="https://user-images.githubusercontent.com/26264600/85176858-62821500-b2ad-11ea-8b5d-bbe509546f02.png">

For two observations:
<img width="1440" alt="Screenshot 2020-06-20 04 10 47" src="https://user-images.githubusercontent.com/26264600/85176914-804f7a00-b2ad-11ea-9509-4c1d031b1fcc.png">
