### PR TITLE
Add new color for stacked sequential IRIS datasets loaded via directory importer

### DIFF
--- a/glue_solar/instruments/iris/loader.py
+++ b/glue_solar/instruments/iris/loader.py
@@ -127,6 +127,7 @@ class QtIRISImporter(QtWidgets.QDialog):
             w_data.coords = window_data.wcs
             w_data.add_component(Component(window_data.data),
                                  f"{window.replace(' ', '_')}")
+            w_data.style = VisualAttributes(color='#7A617C')
             self.datasets.append(w_data)
 
     def finalize(self):


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description
Add a deep purple iris `color` to the stacked sequential IRIS datasets loaded into `glue` with the IRIS OBS directory importer, so as to better set them apart from the rest visually. 

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->
