### PR TITLE
Update glue_solar import statements to match glue structure

### DIFF
--- a/glue_solar/core/core.py
+++ b/glue_solar/core/core.py
@@ -8,7 +8,8 @@ import sunpy.map
 from sunpy.map.mapbase import GenericMap
 
 from glue.config import data_factory, importer, qglue_parser
-from glue.core import Component, Data
+from glue.core.data import Data
+from glue.core.component import Component
 from glue.core.visual import VisualAttributes
 from glue.core.data_factories import is_fits
 

--- a/glue_solar/core/sunpy_maps/loader.py
+++ b/glue_solar/core/sunpy_maps/loader.py
@@ -1,7 +1,8 @@
 import os
 from pathlib import Path
 
-from glue.core import Component, Data
+from glue.core.data import Data
+from glue.core.component import Component
 from glue.core.visual import VisualAttributes
 from glue.utils.qt import get_qapp
 from glue.utils.qt.helpers import load_ui

--- a/glue_solar/instruments/iris/iris.py
+++ b/glue_solar/instruments/iris/iris.py
@@ -8,7 +8,8 @@ from qtpy import QtWidgets
 from astropy.io import fits
 
 from glue.config import data_factory, importer, qglue_parser
-from glue.core import Component, Data
+from glue.core.component import Component
+from glue.core.data import Data
 from glue.core.data_factories import load_data
 from glue.core.coordinates import WCSCoordinates
 from glue.core.visual import VisualAttributes

--- a/glue_solar/instruments/iris/loader.py
+++ b/glue_solar/instruments/iris/loader.py
@@ -3,12 +3,15 @@ from pathlib import Path
 
 from astropy.io import fits
 
-from glue.core import Component, Data
+from glue.core.component import Component
 from glue.core.coordinates import WCSCoordinates
+from glue.core.data import Data
 from glue.core.visual import VisualAttributes
 from glue.utils.qt import get_qapp
 from glue.utils.qt.helpers import load_ui
+
 from sunraster.io.iris import read_iris_spectrograph_level2_fits
+
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 

--- a/glue_solar/tests/test_pixel_extraction.py
+++ b/glue_solar/tests/test_pixel_extraction.py
@@ -1,6 +1,6 @@
 import numpy as np
 from glue.app.qt import GlueApplication
-from glue.core import Data
+from glue.core.data import Data
 from glue.utils.qt import process_events
 from glue.viewers.image.qt import ImageViewer
 from numpy.testing import assert_allclose

--- a/scripts/iris_viewer.py
+++ b/scripts/iris_viewer.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 from glue.app.qt.application import GlueApplication
-from glue.core import Data, DataCollection
+from glue.core.data import Data
+from glue.core.data_collection import DataCollection
 from glue.core.data_factories import load_data
-from glue.plugins.wcs_autolinking.wcs_autolinking import wcs_autolink
 from glue_solar.instruments.iris import _parse_iris_raster
 from sunraster.io.iris import read_iris_spectrograph_level2_fits
 


### PR DESCRIPTION
<!-- # Pull Request Template -->

## Description
Update the `import` statements in `glue-solar` pertaining to `Component` and `Data` in `glue.core`'s `component` and `data` modules respectively to better reflect `glue`'s structure. 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
