### PR TITLE
Add missing PySide2 dependency for Tox build_docs environment

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,3 +7,4 @@ python:
         path: .
         extra_requirements:
           - docs
+          - qt

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ tests =
     mock
 qt =
     PyQt5
+    PySide2
 docs =
     sphinx
     sphinx-automodapi

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ tests =
     mock
 qt =
     PyQt5
-    PySide2
 docs =
     sphinx
     sphinx-automodapi


### PR DESCRIPTION
## Description

The RTD build of `glue-solar` has been failing since the `pyside2` dependency has been missing, hence this PR to add it as an override in `tox.ini`. 