### PR TITLE
Take the preferred colormap from the loaded map

### DIFF
--- a/changelog/+maps-preferred-cmap.trivial.rst
+++ b/changelog/+maps-preferred-cmap.trivial.rst
@@ -1,0 +1,1 @@
+The sunpy Map importer takes the preferred colormap from the loaded map instead of from its raw argument.

--- a/glue_solar/sources/loaders/maps.py
+++ b/glue_solar/sources/loaders/maps.py
@@ -70,7 +70,7 @@ class QtSunpyMapImporter(QtWidgets.QDialog):
         )  # preferred way, preserves more info in some cases
         data.meta = sunpy_map_loaded.meta
         data.add_component(Component(sunpy_map_loaded.data), sunpy_map_loaded.name)
-        data.style = VisualAttributes(color="#FDB813", preferred_cmap=sunpy_map.cmap)
+        data.style = VisualAttributes(color="#FDB813", preferred_cmap=sunpy_map_loaded.cmap)
 
         self.datasets.append(data)
 


### PR DESCRIPTION
One-line fix in the sunpy Map importer: `preferred_cmap` now comes from the loaded `Map` object instead of the raw function argument, which only worked when a `Map` happened to be passed in. Carved out of #44.