### PR TITLE
Remove the empty sst module

### DIFF
--- a/changelog/+remove-sst.trivial.rst
+++ b/changelog/+remove-sst.trivial.rst
@@ -1,0 +1,1 @@
+The empty ``glue_solar.sources.sst`` module is removed.

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -7,8 +7,5 @@ API Reference
 .. automodapi:: glue_solar.sources.iris
    :no-inheritance-diagram:
 
-.. automodapi:: glue_solar.sources.sst
-   :no-inheritance-diagram:
-
 .. automodapi:: glue_solar.sources.maps
    :no-inheritance-diagram:

--- a/glue_solar/__init__.py
+++ b/glue_solar/__init__.py
@@ -2,10 +2,12 @@ from glue.config import colormaps
 
 from sunpy.visualization.colormaps import cmlist
 
-from glue_solar.sources import iris, maps, sst
+from glue_solar.sources import iris, maps
+
 from glue_solar.version import version as __version__
 
-__all__ = ["setup", "__version__", "iris", "maps", "sst"]
+__all__ = ["setup", "__version__", "iris", "maps"]
+
 
 def setup():
     # Enables sunpy colormaps to be used in glueviz


### PR DESCRIPTION
`glue_solar/sources/sst.py` is an empty file; drop it and its mentions in `__init__.py` and the API reference. Carved out of #44.