### PR TITLE
Set QT_API and request the qt extra in tox

### DIFF
--- a/changelog/+tox-qt.trivial.rst
+++ b/changelog/+tox-qt.trivial.rst
@@ -1,0 +1,1 @@
+The tox test and docs environments pin ``QT_API=pyqt6`` and request the ``qt`` extra.

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ pass_env =
 set_env =
     COVERAGE_FILE={toxinidir}/.coverage
     MPLBACKEND = agg
+    QT_API = pyqt6
     QT_QPA_PLATFORM = offscreen
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 deps =
@@ -40,6 +41,7 @@ deps =
 # The following indicates which extras_require will be installed
 extras =
     tests
+    qt
 commands_pre =
     oldestdeps: minimum_dependencies glue_solar --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt
@@ -74,5 +76,6 @@ change_dir =
     docs
 extras =
     docs
+    qt
 commands =
     sphinx-build -j auto --color -W --keep-going -b html -d _build/.doctrees . _build/html {posargs}


### PR DESCRIPTION
Pins `QT_API=pyqt6` and adds `qt` to the tox extras for the test and docs environments. Note: `pyproject.toml` does not define a `qt` extra, so the `extras = qt` lines are currently a pip warning/no-op — kept as on the original branch. Carved out of #44.