### PR TITLE
Drop the undefined qt extra from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,6 @@ deps =
 # The following indicates which extras_require will be installed
 extras =
     tests
-    qt
 commands_pre =
     oldestdeps: minimum_dependencies glue_solar --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt
@@ -76,6 +75,5 @@ change_dir =
     docs
 extras =
     docs
-    qt
 commands =
     sphinx-build -j auto --color -W --keep-going -b html -d _build/.doctrees . _build/html {posargs}


### PR DESCRIPTION
Fixes the CI failure `extras not found for package glue-solar: qt (available: docs, tests)`.

The original feature branch defined a `qt = ["PyQt6"]` extra in pyproject.toml with matching `extras = qt` lines in tox.ini. A later cleanup moved the Qt binding into the mandatory `glue-qt[qt]>=0.4.0` dependency and removed the extra, but left the tox lines behind; #47 carried them to main and tox 4 hard-fails on unknown extras. `QT_API=pyqt6` stays.