### PR TITLE
Drop the stale QT_API pin from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,6 @@ pass_env =
 set_env =
     COVERAGE_FILE={toxinidir}/.coverage
     MPLBACKEND = agg
-    QT_API = pyqt6
     QT_QPA_PLATFORM = offscreen
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 deps =


### PR DESCRIPTION
Fixes the CI collection error `qtpy.PythonQtWarning: Selected binding 'pyqt6' could not be found; falling back to 'pyqt5'`.

`glue-qt[qt]` installs PyQt5, but tox still pinned `QT_API=pyqt6` — a leftover from when the branch installed PyQt6 through its own `qt` extra (removed along with the extra's other half in #48). qtpy's fallback warning becomes an error under pytest.ini's `filterwarnings = error`. Without the pin qtpy auto-selects the installed binding.